### PR TITLE
Fix validation and auto-increment IDs

### DIFF
--- a/ComprasArchivo.cpp
+++ b/ComprasArchivo.cpp
@@ -45,7 +45,7 @@ bool ComprasArchivo::modificar(Compras maxi, int pos) {
 bool ComprasArchivo::eliminar(Compras maxi, int pos) {
     FILE* archivo = fopen(_nombreArchivo.c_str(), "rb+");
     if (archivo == nullptr) return false;
-    // Se supone que Compras tiene un m‚todo setActivo(false);
+    // Se supone que Compras tiene un mtodo setActivo(false);
     maxi.setActivo(false);
     fseek(archivo, sizeof(Compras) * pos, SEEK_SET);
     bool exito = fwrite(&maxi, sizeof(Compras), 1, archivo);
@@ -60,7 +60,7 @@ int ComprasArchivo::listarTodos() {
     Compras maxi;
     while (fread(&maxi, sizeof(Compras), 1, archivo)) {
         if (maxi.getActivo()) {
-            maxi.mostrar();  // Suponiendo que tiene un m‚todo mostrar()
+            maxi.mostrar();  // Suponiendo que tiene un mtodo mostrar()
             Comprascargadas++;
         }
     }
@@ -75,4 +75,8 @@ int ComprasArchivo::getCantidadRegistros() {
     int cant = ftell(archivo) / sizeof(Compras);
     fclose(archivo);
     return cant;
+}
+
+int ComprasArchivo::getNuevoID(){
+    return getCantidadRegistros() + 1;
 }

--- a/ComprasArchivo.h
+++ b/ComprasArchivo.h
@@ -16,4 +16,5 @@ public:
     bool eliminar(Compras maxi, int pos);
     int listarTodos();
     int getCantidadRegistros();
+    int getNuevoID();
 };

--- a/MENUproveedores.cpp
+++ b/MENUproveedores.cpp
@@ -1,5 +1,5 @@
 #include <iostream>
-#include "MENUProveedores.h"
+#include "MENUproveedores.h"
 #include "Usuario_maestro.h"
 using namespace std;
 

--- a/Productos.cpp
+++ b/Productos.cpp
@@ -54,20 +54,22 @@ bool Productos::settipoProducto(std::string tipo) {
 bool Productos::setprecioUnitario(float precio) {
 
     if (precio < 0) {
-            cout << "Error: el precio no puede ser negativo..." << endl;
-            return 0;
-        }
-        _precioUnitario = precio;
+        cout << "Error: el precio no puede ser negativo..." << endl;
+        return false;
     }
+    _precioUnitario = precio;
+    return true;
+}
 
 
 
 bool Productos::setstock(int stock) {
     if (stock < 0) {
-            cout << "Error: el precio no puede ser negativo..." << endl;
-            return 0;
-        }
-     _stock = stock;
+        cout << "Error: el stock no puede ser negativo..." << endl;
+        return false;
+    }
+    _stock = stock;
+    return true;
 }
 
 void Productos::setEstado (bool estado){

--- a/ProveedorArchivo.cpp
+++ b/ProveedorArchivo.cpp
@@ -7,6 +7,14 @@ ProveedorArchivo::ProveedorArchivo(){
 _nombreArchivo="Proveedores.dat";
 }
 
+bool ProveedorArchivo::Guardar(Proveedores PROV){
+ FILE *Provfile = fopen(_nombreArchivo.c_str(), "ab");
+ if(Provfile==nullptr) return false;
+ bool guardado = fwrite(&PROV, sizeof(Proveedores), 1, Provfile);
+ fclose(Provfile);
+ return guardado;
+}
+
 
  Proveedores ProveedorArchivo::leerUno(int pos){
  FILE *ProvArchivo = fopen(_nombreArchivo.c_str(), "rb");
@@ -133,7 +141,7 @@ int ProveedorArchivo::buscarProveedor(std::string IDproveedor){
 
  }
 
- bool ProveedorArchivo::leerMuchos(Proveedores reg[], int cantidad){
+bool ProveedorArchivo::leerMuchos(Proveedores reg[], int cantidad){
  FILE *pFile;
 
  pFile= fopen (_nombreArchivo.c_str(), "rb");
@@ -146,4 +154,8 @@ int ProveedorArchivo::buscarProveedor(std::string IDproveedor){
 fread(reg, sizeof(Proveedores), cantidad, pFile);
 fclose(pFile);
  return true;
+}
+
+int ProveedorArchivo::getNuevoID(){
+    return getCantidadRegistros() + 1;
 }

--- a/ProveedorArchivo.h
+++ b/ProveedorArchivo.h
@@ -22,6 +22,7 @@ public:
     bool getregActivo();
 
     bool leerMuchos(Proveedores reg[], int cantidad);
+    int getNuevoID();
 };
 
 

--- a/Usuario_maestro.cpp
+++ b/Usuario_maestro.cpp
@@ -19,10 +19,9 @@ float precioUnitario;
 int stock;
 bool caso1, caso2, caso3, caso4, caso5;
 
- cout <<"Ingrese ID Producto"<<endl;
- cin.ignore();
- getline(cin, IDProducto);
- caso1=prodCarga.setIDProducto(IDProducto);
+    IDProducto = std::to_string(registro.getNuevoID());
+    caso1 = prodCarga.setIDProducto(IDProducto);
+    cout << "ID asignado: " << IDProducto << endl;
 
 cout << "Ingrese Nombre Producto"<< endl;
 getline(cin, nombreProducto);
@@ -34,7 +33,7 @@ caso3=prodCarga.settipoProducto(tipoProducto);
 
 cout << "Ingrese precio Unitario"<< endl;
 while (!(cin >> precioUnitario)) {
-        cout << "Entrada no v lida. Por favor ingresa un n£mero: "<<endl;
+        cout << "Entrada no vÂ lida. Por favor ingresa un nÂ£mero: "<<endl;
         cin.clear();
         cin.ignore();
     }
@@ -42,7 +41,7 @@ caso4=prodCarga.setprecioUnitario(precioUnitario);
 
 cout<<"Ingrese stock"<< endl;
 while (!(cin >> stock)) {
-        cout << "Entrada no v lida. Por favor ingresa un n£mero: "<<endl;
+        cout << "Entrada no vÂ lida. Por favor ingresa un nÂ£mero: "<<endl;
         cin.clear();
         cin.ignore();
     }
@@ -117,7 +116,7 @@ int Opcion;
         cout << "4. Precio unitario"<<endl;
         cout << "5. Stock"<<endl;
         cout << "0. Salir" << endl;
-        cout << "Elija una opci¢n:  ";
+        cout << "Elija una opciÂ¢n:  ";
   cin >> Opcion;
 
       switch(Opcion){
@@ -284,10 +283,9 @@ char CUIT_str[30], Nombre_str[30], Telefono_str[30], Email_str[30], Direccion_st
 char idProv_str[30];
 bool Estado=true;
 
-cout << "Carga de IDProveedor" << endl;
-cin >> idProv_str;
-proveedor.setidProveedor(idProv_str);
-cin.ignore();
+    strcpy(idProv_str, std::to_string(ArchivodeProveedores.getNuevoID()).c_str());
+    proveedor.setidProveedor(idProv_str);
+    cout << "ID asignado: " << idProv_str << endl;
 
 cout << "Carga de CUIT" << endl;
 cin >> CUIT_str;
@@ -609,9 +607,8 @@ float Importe;
 Compras compra;
 ComprasArchivo Arch;
 
-cout << "Carga ID de la compra" << endl;
-cin.ignore();
-getline(cin,idCompra);
+    idCompra = std::to_string(Arch.getNuevoID());
+    cout << "ID asignado: " << idCompra << endl;
 
 cout << "Carga ID de Proveedor" << endl;
 getline(cin,idProv);


### PR DESCRIPTION
## Summary
- return bool in `Productos` setters
- fix include case in `MENUproveedores.cpp`
- add saving helper and new-id method to `ProveedorArchivo`
- add new-id method to `ComprasArchivo`
- assign IDs automatically when creating products, providers and purchases

## Testing
- `g++ -std=c++17 $(ls *.cpp | grep -v Listados.cpp) -o maxi && echo "compiled"`

------
https://chatgpt.com/codex/tasks/task_e_68603abf25e8832d9f6f3eacbff41b99