### PR TITLE
Fix menu option handling

### DIFF
--- a/MENUProducto.cpp
+++ b/MENUProducto.cpp
@@ -18,8 +18,7 @@ int Opcion;
         cout << "2. Eliminar producto"<<endl;
         cout << "3. Modificar datos del producto"<<endl;
         cout << "0. Salir" << endl;
-  cin.ignore(numeric_limits<streamsize>::max(), '\n');
-        cout << "Elija una opci¢n:  ";
+        cout << "Elija una opcion:  ";
   cin >> Opcion;
   cin.ignore(numeric_limits<streamsize>::max(), '\n');
 
@@ -36,6 +35,8 @@ int Opcion;
        cargas.modificarProducto();
     break;
 
+   case 0:
+        break;
    default:
         cout << "Elija una opcion valida:" << endl;
 

--- a/MENUproveedores.cpp
+++ b/MENUproveedores.cpp
@@ -38,7 +38,8 @@ int Opcion;
    case 4:
        Cargaprov.modificarProveedores();
     break;
-
+   case 0:
+        break;
     default:
         cout << "Elija una opcion valida:" << endl;
 

--- a/Usuario_maestro.cpp
+++ b/Usuario_maestro.cpp
@@ -214,7 +214,7 @@ cout<<"Ingrese ID Producto a modificar :"<<endl;
             getline(cin, tipoProducto);
             setter.settipoProducto(tipoProducto);
 
-        if (registro.Guardar(setter, posicion)){
+        if (registro.Guardar(setter, posicion3)){
             cout<<"Registro modificado correctamente..."<<endl;
         }
         else{
@@ -257,7 +257,7 @@ cout<<"Ingrese ID Producto a modificar :"<<endl;
     break;
 
    case 5:
-         int posicion5;
+        int posicion5;
 cout<<"Ingrese ID Producto a modificar :"<<endl;
     cin.ignore();
     getline(cin, idProducto);
@@ -283,6 +283,8 @@ cout<<"Ingrese ID Producto a modificar :"<<endl;
 
     break;
 
+   case 0:
+        break;
     default:
         cout << "Elija una opcion valida:" << endl;
 
@@ -446,7 +448,7 @@ int Opcion;
         cout << "3. Nombre del Proveedor"<<endl;
         cout << "4. Telefono"<<endl;
         cout << "5. Email"<<endl;
-        cout << "5. Direccion"<<endl;
+        cout << "6. Direccion"<<endl;
         cout << "0. Salir" << endl;
         cout << "Elija una opcion:  ";
   cin >> Opcion;
@@ -589,7 +591,7 @@ cout<<"Ingrese Email a modificar :"<<endl;
 
     break;
 
-    case 6:
+   case 6:
          int pos6;
 cout<<"Ingrese Direccion a modificar :"<<endl;
     cin.ignore();
@@ -616,6 +618,8 @@ cout<<"Ingrese Direccion a modificar :"<<endl;
 
     break;
 
+    case 0:
+        break;
     default:
         cout << "Elija una opcion valida:" << endl;
 


### PR DESCRIPTION
## Summary
- avoid invalid message on exit in product menu
- add exit case to providers menu
- fix typos and add exit cases in product and provider modification functions

## Testing
- `g++ -std=c++11 -o main *.cpp`
- `./main <<EOF
0
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6861adbc310c832d87afb2c8b0bcafe7